### PR TITLE
REE-79152 - create walltime columns based on TIMESTAMP_TZ

### DIFF
--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -261,7 +261,7 @@ def add_wall_time_columns(dataset):
     existing_column_names = {col['column_name'] for col in dataset['columns_new']}
 
     for col in dataset['columns_new']:
-        if col.get('type') == 'TIMESTAMP_LTZ':
+        if col.get('type').upper() == 'TIMESTAMP_LTZ':
             original_col_name = col['column_name']
             wall_time_col_name = f"{original_col_name}_WT"
 

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -246,7 +246,7 @@ def merge_columns_info(dataset, dbt_tables, debug_dir):
 def add_wall_time_columns(dataset):
     """
     Adds derived TIMESTAMP_NTZ 'wall time' columns for each TIMESTAMP_LTZ column in the dataset,
-    copying all properties from the original column except for column_name, expression, and verbose_name.
+    copying all properties from the original column except for column_name, expression, verbose_name, and type.
 
     Args:
         dataset (dict): A Superset dataset object with a 'columns_new' list.
@@ -279,6 +279,7 @@ def add_wall_time_columns(dataset):
             new_col['expression'] = f"{original_col_name}::timestamp_ntz"
             original_verbose_name = col.get('verbose_name', original_col_name)
             new_col['verbose_name'] = f"{original_verbose_name} (wall time)"
+            new_col['type'] = 'TIMESTAMP_NTZ'
 
             wt_columns.append(new_col)
 

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -261,7 +261,7 @@ def add_wall_time_columns(dataset):
     existing_column_names = {col['column_name'] for col in dataset['columns_new']}
 
     for col in dataset['columns_new']:
-        if col.get('type').upper() == 'TIMESTAMP_LTZ':
+        if col.get('type').upper() == 'TIMESTAMP_TZ':
             original_col_name = col['column_name']
             wall_time_col_name = f"{original_col_name}_WT"
 

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -247,6 +247,7 @@ def main(dbt_project_dir, dbt_db_name, superset_db_id, superset_debug_dir, super
 
     sst_physical_datasets = filter_by_kind(sst_datasets, 'physical')
     logging.info("There are %d physical datasets in Superset.", len(sst_physical_datasets))
+    logging.info("Test")
     logging.info(sst_physical_datasets)
 
     sst_virtual_datasets = filter_by_kind(sst_datasets, 'virtual')

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -262,7 +262,7 @@ def add_wall_time_columns(dataset):
 
     print(dataset)
     for col in dataset['columns_new']:
-        if col.get('type').upper() == 'TIMESTAMP_TZ':
+        if col.get('type') == 'TIMESTAMP_TZ':
             original_col_name = col['column_name']
             wall_time_col_name = f"{original_col_name}_WT"
 

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -247,6 +247,7 @@ def main(dbt_project_dir, dbt_db_name, superset_db_id, superset_debug_dir, super
 
     sst_physical_datasets = filter_by_kind(sst_datasets, 'physical')
     logging.info("There are %d physical datasets in Superset.", len(sst_physical_datasets))
+    logging.info(sst_physical_datasets)
 
     sst_virtual_datasets = filter_by_kind(sst_datasets, 'virtual')
     logging.info("There are %d virtual datasets in Superset.", len(sst_virtual_datasets))

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -336,18 +336,17 @@ def main(dbt_project_dir, dbt_db_name, superset_db_id, superset_debug_dir, super
         sst_dataset_id = sst_physical_datasets[sst_dataset]['dataset_id']
 
         logging.info("Processing dataset ID: %d, name: %s.", sst_dataset_id, sst_dataset)
-        if sst_dataset_id == 1325:
-            # Only process datasets which exist in dbt:
-            if sst_dataset in dbt_tables:
-                try:
-                    if superset_refresh_columns:
-                        superset.refresh_dataset(sst_dataset_id)
-                    sst_dataset_w_cols = superset.get_columns(sst_dataset_id)
-                    sst_dataset_w_cols_new = merge_columns_info(sst_dataset_w_cols, dbt_tables, superset_debug_dir)
-                    sst_dataset_w_cols_new = add_wall_time_columns(sst_dataset_w_cols_new)
-                    superset.put_columns(sst_dataset_w_cols_new, superset_debug_dir)
-                except Exception as e:
-                    logging.error("The dataset named %s with ID=%d wasn't updated. Check the error below.",
-                                sst_dataset, sst_dataset_id, exc_info=e)
+        # Only process datasets which exist in dbt:
+        if sst_dataset in dbt_tables:
+            try:
+                if superset_refresh_columns:
+                    superset.refresh_dataset(sst_dataset_id)
+                sst_dataset_w_cols = superset.get_columns(sst_dataset_id)
+                sst_dataset_w_cols_new = merge_columns_info(sst_dataset_w_cols, dbt_tables, superset_debug_dir)
+                sst_dataset_w_cols_new = add_wall_time_columns(sst_dataset_w_cols_new)
+                superset.put_columns(sst_dataset_w_cols_new, superset_debug_dir)
+            except Exception as e:
+                logging.error("The dataset named %s with ID=%d wasn't updated. Check the error below.",
+                            sst_dataset, sst_dataset_id, exc_info=e)
 
-    logging.info("All done!")
+logging.info("All done!")

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -260,6 +260,7 @@ def add_wall_time_columns(dataset):
     wt_columns = []
     existing_column_names = {col['column_name'] for col in dataset['columns_new']}
 
+    print(dataset)
     for col in dataset['columns_new']:
         if col.get('type').upper() == 'TIMESTAMP_TZ':
             original_col_name = col['column_name']

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -4,7 +4,6 @@ import os
 import re
 import copy
 
-
 from bs4 import BeautifulSoup
 from markdown import markdown
 

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -336,18 +336,18 @@ def main(dbt_project_dir, dbt_db_name, superset_db_id, superset_debug_dir, super
         sst_dataset_id = sst_physical_datasets[sst_dataset]['dataset_id']
 
         logging.info("Processing dataset ID: %d, name: %s.", sst_dataset_id, sst_dataset)
-
-        # Only process datasets which exist in dbt:
-        if sst_dataset in dbt_tables:
-            try:
-                if superset_refresh_columns:
-                    superset.refresh_dataset(sst_dataset_id)
-                sst_dataset_w_cols = superset.get_columns(sst_dataset_id)
-                sst_dataset_w_cols_new = merge_columns_info(sst_dataset_w_cols, dbt_tables, superset_debug_dir)
-                sst_dataset_w_cols_new = add_wall_time_columns(sst_dataset_w_cols_new)
-                superset.put_columns(sst_dataset_w_cols_new, superset_debug_dir)
-            except Exception as e:
-                logging.error("The dataset named %s with ID=%d wasn't updated. Check the error below.",
-                            sst_dataset, sst_dataset_id, exc_info=e)
+        if sst_dataset_id == 1325:
+            # Only process datasets which exist in dbt:
+            if sst_dataset in dbt_tables:
+                try:
+                    if superset_refresh_columns:
+                        superset.refresh_dataset(sst_dataset_id)
+                    sst_dataset_w_cols = superset.get_columns(sst_dataset_id)
+                    sst_dataset_w_cols_new = merge_columns_info(sst_dataset_w_cols, dbt_tables, superset_debug_dir)
+                    sst_dataset_w_cols_new = add_wall_time_columns(sst_dataset_w_cols_new)
+                    superset.put_columns(sst_dataset_w_cols_new, superset_debug_dir)
+                except Exception as e:
+                    logging.error("The dataset named %s with ID=%d wasn't updated. Check the error below.",
+                                sst_dataset, sst_dataset_id, exc_info=e)
 
     logging.info("All done!")

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -260,7 +260,6 @@ def add_wall_time_columns(dataset):
     wt_columns = []
     existing_column_names = {col['column_name'] for col in dataset['columns_new']}
 
-    print(dataset)
     for col in dataset['columns_new']:
         if col.get('type') == 'TIMESTAMP_TZ':
             original_col_name = col['column_name']

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -295,8 +295,6 @@ def main(dbt_project_dir, dbt_db_name, superset_db_id, superset_debug_dir, super
 
     sst_physical_datasets = filter_by_kind(sst_datasets, 'physical')
     logging.info("There are %d physical datasets in Superset.", len(sst_physical_datasets))
-    logging.info("Test")
-    logging.info(sst_physical_datasets)
 
     sst_virtual_datasets = filter_by_kind(sst_datasets, 'virtual')
     logging.info("There are %d virtual datasets in Superset.", len(sst_virtual_datasets))
@@ -348,9 +346,6 @@ def main(dbt_project_dir, dbt_db_name, superset_db_id, superset_debug_dir, super
                 sst_dataset_w_cols = superset.get_columns(sst_dataset_id)
                 sst_dataset_w_cols_new = merge_columns_info(sst_dataset_w_cols, dbt_tables, superset_debug_dir)
                 sst_dataset_w_cols_new = add_wall_time_columns(sst_dataset_w_cols_new)
-                logging.info(f"Old dataset {sst_dataset_w_cols}")
-                logging.info(f"New dataset {sst_dataset_w_cols}")
-                print(sst_dataset_w_cols_new)
                 superset.put_columns(sst_dataset_w_cols_new, superset_debug_dir)
             except Exception as e:
                 logging.error("The dataset named %s with ID=%d wasn't updated. Check the error below.",

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -264,7 +264,7 @@ def add_wall_time_columns(dataset):
     for col in dataset['columns_new']:
         if col.get('type') == 'TIMESTAMP_LTZ':
             original_col_name = col['column_name']
-            wall_time_col_name = f"{original_col_name}_wt"
+            wall_time_col_name = f"{original_col_name}_WT"
 
             # Skip if the wall time column already exists
             if wall_time_col_name in existing_column_names:

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -299,6 +299,9 @@ def main(dbt_project_dir, dbt_db_name, superset_db_id, superset_debug_dir, super
                     superset.refresh_dataset(sst_dataset_id)
                 sst_dataset_w_cols = superset.get_columns(sst_dataset_id)
                 sst_dataset_w_cols_new = merge_columns_info(sst_dataset_w_cols, dbt_tables, superset_debug_dir)
+                logging.info(f"Old dataset {sst_dataset_w_cols}")
+                logging.info(f"New dataset {sst_dataset_w_cols}")
+                print(sst_dataset_w_cols_new)
                 superset.put_columns(sst_dataset_w_cols_new, superset_debug_dir)
             except Exception as e:
                 logging.error("The dataset named %s with ID=%d wasn't updated. Check the error below.",

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -2,6 +2,8 @@ import json
 import logging
 import os
 import re
+import copy
+
 
 from bs4 import BeautifulSoup
 from markdown import markdown
@@ -239,6 +241,51 @@ def merge_columns_info(dataset, dbt_tables, debug_dir):
     dataset['columns_new'] = columns_new
 
     return dataset
+
+
+def add_wall_time_columns(dataset):
+    """
+    Adds derived TIMESTAMP_NTZ 'wall time' columns for each TIMESTAMP_LTZ column in the dataset,
+    copying all properties from the original column except for column_name, expression, and verbose_name.
+
+    Args:
+        dataset (dict): A Superset dataset object with a 'columns_new' list.
+
+    Returns:
+        dict: The updated dataset with new wall time columns appended.
+    """
+    if 'columns_new' not in dataset:
+        logging.warning("No 'columns_new' in dataset. Skipping wall time columns.")
+        return dataset
+
+    wt_columns = []
+    existing_column_names = {col['column_name'] for col in dataset['columns_new']}
+
+    for col in dataset['columns_new']:
+        if col.get('type') == 'TIMESTAMP_LTZ':
+            original_col_name = col['column_name']
+            wall_time_col_name = f"{original_col_name}_wt"
+
+            # Skip if the wall time column already exists
+            if wall_time_col_name in existing_column_names:
+                logging.info(f"Wall time column {wall_time_col_name} already exists. Skipping.")
+                continue
+
+            # Copy everything from original column
+            new_col = copy.deepcopy(col)
+
+            # Override required fields
+            new_col['column_name'] = wall_time_col_name
+            new_col['expression'] = f"{original_col_name}::timestamp_ntz"
+            original_verbose_name = col.get('verbose_name', original_col_name)
+            new_col['verbose_name'] = f"{original_verbose_name} (wall time)"
+
+            wt_columns.append(new_col)
+
+    dataset['columns_new'].extend(wt_columns)
+    logging.info(f"Added {len(wt_columns)} wall time columns.")
+    return dataset
+
 
 def main(dbt_project_dir, dbt_db_name, superset_db_id, superset_debug_dir, superset_refresh_columns, superset):
 

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -346,6 +346,7 @@ def main(dbt_project_dir, dbt_db_name, superset_db_id, superset_debug_dir, super
                     superset.refresh_dataset(sst_dataset_id)
                 sst_dataset_w_cols = superset.get_columns(sst_dataset_id)
                 sst_dataset_w_cols_new = merge_columns_info(sst_dataset_w_cols, dbt_tables, superset_debug_dir)
+                sst_dataset_w_cols_new = add_wall_time_columns(sst_dataset_w_cols_new)
                 logging.info(f"Old dataset {sst_dataset_w_cols}")
                 logging.info(f"New dataset {sst_dataset_w_cols}")
                 print(sst_dataset_w_cols_new)

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -336,7 +336,7 @@ def main(dbt_project_dir, dbt_db_name, superset_db_id, superset_debug_dir, super
         sst_dataset_id = sst_physical_datasets[sst_dataset]['dataset_id']
 
         logging.info("Processing dataset ID: %d, name: %s.", sst_dataset_id, sst_dataset)
-        if sst_dataset_id == '1325':
+        if sst_dataset_id == 1325:
             # Only process datasets which exist in dbt:
             if sst_dataset in dbt_tables:
                 try:

--- a/dbt_superset_lineage/push_physical_datasets.py
+++ b/dbt_superset_lineage/push_physical_datasets.py
@@ -336,7 +336,7 @@ def main(dbt_project_dir, dbt_db_name, superset_db_id, superset_debug_dir, super
         sst_dataset_id = sst_physical_datasets[sst_dataset]['dataset_id']
 
         logging.info("Processing dataset ID: %d, name: %s.", sst_dataset_id, sst_dataset)
-        if sst_dataset_id == 1325:
+        if sst_dataset_id == '1325':
             # Only process datasets which exist in dbt:
             if sst_dataset in dbt_tables:
                 try:

--- a/dbt_superset_lineage/superset_api.py
+++ b/dbt_superset_lineage/superset_api.py
@@ -194,8 +194,6 @@ class Superset:
         body = dataset['meta_new']
         body['columns'] = dataset['columns_new']
 
-        logging.info(f"Columns in put_columns {dataset['columns_new']}")
-
         if debug_dir is not None:
             update_body_file_path = os.path.join(debug_dir, f'update_body__dataset_{id}.json')
             with open(update_body_file_path, 'w') as fp:

--- a/dbt_superset_lineage/superset_api.py
+++ b/dbt_superset_lineage/superset_api.py
@@ -194,6 +194,8 @@ class Superset:
         body = dataset['meta_new']
         body['columns'] = dataset['columns_new']
 
+        logging.info(f"Columns in put_columns {dataset['columns_new']}")
+
         if debug_dir is not None:
             update_body_file_path = os.path.join(debug_dir, f'update_body__dataset_{id}.json')
             with open(update_body_file_path, 'w') as fp:


### PR DESCRIPTION
This pull request adds a new utility function to automatically generate "wall time" columns for each `TIMESTAMP_TZ` column in Superset datasets. It also integrates this function into the dataset processing workflow for a specific dataset. The changes help ensure that all relevant datasets have derived `TIMESTAMP_NTZ` columns for easier querying and analysis.

Enhancements to dataset column handling:

* Added a new function `add_wall_time_columns` to generate derived `TIMESTAMP_NTZ` ("wall time") columns for every `TIMESTAMP_TZ` column in a Superset dataset. The new columns copy most properties from the original and use a cast expression for conversion.
* Integrated `add_wall_time_columns` into the main processing flow, so that the function is called when updating columns for dataset ID 1325.
* Imported the `copy` module to support deep copying of column definitions in the new function.